### PR TITLE
kubectl-builder: add a :flags parameter

### DIFF
--- a/src/exoscale/kubectl/helpers.clj
+++ b/src/exoscale/kubectl/helpers.clj
@@ -72,6 +72,7 @@
     - `:resource`: the resource name.
     - `:labels`: labels as {key1 value1, key2 value2 ...}
     - `:stdin`: the value of stdin.
+    - `:flags`: additional flags for the command.
     - `:yaml?`: enable yaml formatting.
     - `:json?`: enable json formatting."
   ([resource-type operation config]
@@ -87,6 +88,9 @@
 
      (seq (:labels config))
      (labels (:labels config))
+
+     (:flags config)
+     (update :flags concat (:flags config))
 
      (:json? config) json
      (:yaml? config) yaml)))

--- a/test/clojure_kubectl/helpers_test.clj
+++ b/test/clojure_kubectl/helpers_test.clj
@@ -219,9 +219,12 @@
           :command :delete
           :type :service
           :resource :service-name
-          :flags [[:-n :backend]]}
+          :flags [[:-n :backend]
+                  :--foo
+                  [:--bar "value"]]}
          (delete-services {:namespace :backend
-                           :resource :service-name}))))
+                           :resource :service-name
+                           :flags [:--foo [:--bar "value"]]}))))
 
 (deftest get-service-test
   (is (= {:path     "kubectl"


### PR DESCRIPTION
This parameter can be used to pass extract flags to the kubectl command.