### PR TITLE
update flags to keep vector type instead of list

### DIFF
--- a/src/exoscale/kubectl/helpers.clj
+++ b/src/exoscale/kubectl/helpers.clj
@@ -61,6 +61,11 @@
   [m value]
   (assoc m :stdin value))
 
+(defn- concat*
+  "same as concat but returns vector"
+  [& args]
+  (into [] (apply concat args)))
+
 (defn kubectl-builder
   "Generic kubectl command builder.
 
@@ -90,7 +95,7 @@
      (labels (:labels config))
 
      (:flags config)
-     (update :flags concat (:flags config))
+     (update :flags concat* (:flags config))
 
      (:json? config) json
      (:yaml? config) yaml)))

--- a/test/clojure_kubectl/helpers_test.clj
+++ b/test/clojure_kubectl/helpers_test.clj
@@ -40,11 +40,12 @@
             :flags [:--dry-run]}
            (-> (kubectl)
                (flag :--dry-run)))))
-  (testing "simple flag"
+  (testing "multiple flags"
     (is (= {:path "kubectl"
-            :flags [:--dry-run]}
+            :flags [[:-l "foo"] [:-l "bar"]]}
            (-> (kubectl)
-               (flag :--dry-run))))))
+               (flag :-l "foo")
+               (flag :-l "bar"))))))
 
 (deftest namespace-test
   (is (= {:path "kubectl"
@@ -111,8 +112,8 @@
           :flags [[:-n :backend]
                   [:-o :json]]}
          (get-pods {:namespace :backend
-                   :resource :foo
-                   :json? true})))
+                    :resource :foo
+                    :json? true})))
 
   (is (= {:path "kubectl"
           :command :get
@@ -123,9 +124,9 @@
                   [:-l "y=two"]
                   [:-o :yaml]]}
          (get-pods {:namespace :backend
-                   :resource :foo
-                   :labels {:x :one :y :two}
-                   :yaml? true})))
+                    :resource :foo
+                    :labels {:x :one :y :two}
+                    :yaml? true})))
 
   (is (= {:path "kubectl"
           :command :get
@@ -224,6 +225,16 @@
           :resource :ingress-name
           :flags [[:-n :backend]]}
          (delete-ingresses {:namespace :backend
+                            :resource :ingress-name})))
+
+  (is (= {:path "kubectl"
+          :command :delete
+          :type :ingress.networking.k8s.io
+          :resource :ingress-name
+          :flags [[:-n :backend]
+                  [:-l "foo"]]}
+         (delete-ingresses {:namespace :backend
+                            :flags [[:-l "foo"]]
                             :resource :ingress-name}))))
 
 (deftest delete-service-test
@@ -236,7 +247,19 @@
                   [:--bar "value"]]}
          (delete-services {:namespace :backend
                            :resource :service-name
-                           :flags [:--foo [:--bar "value"]]}))))
+                           :flags [:--foo [:--bar "value"]]})))
+
+  (is (= {:path "kubectl"
+          :command :delete
+          :type :service
+          :resource :service-name
+          :flags [[:-n :backend]
+                  [:-l "env=production"]
+                  [:--bar "value"]]}
+         (delete-services {:namespace :backend
+                           :labels {:env :production}
+                           :resource :service-name
+                           :flags [[:--bar "value"]]}))))
 
 (deftest get-service-test
   (is (= {:path     "kubectl"
@@ -246,6 +269,17 @@
           :resource :deployment-name
           :type     :service}
          (get-services {:namespace :backend
+                        :labels {:env :production}
+                        :resource :deployment-name})))
+  (is (= {:path     "kubectl"
+          :command  :get
+          :flags    [[:-n :backend]
+                     [:-l "env=production"]
+                     [:-l "bar"]]
+          :resource :deployment-name
+          :type     :service}
+         (get-services {:namespace :backend
+                        :flags [[:-l "bar"]]
                         :labels {:env :production}
                         :resource :deployment-name}))))
 
@@ -257,6 +291,18 @@
           :resource :deployment-name
           :type     :ingress.networking.k8s.io}
          (get-ingresses {:namespace :backend
+                         :labels {:env :production}
+                         :resource :deployment-name})))
+  (is (= {:path     "kubectl"
+          :command  :get
+          :flags    [[:-n :backend]
+                     [:-l "env=production"]
+                     [:-l "foo"]
+                     [:-l "bar"]]
+          :resource :deployment-name
+          :type     :ingress.networking.k8s.io}
+         (get-ingresses {:namespace :backend
+                         :flags [[:-l "foo"] [:-l "bar"]]
                          :labels {:env :production}
                          :resource :deployment-name}))))
 

--- a/test/clojure_kubectl/helpers_test.clj
+++ b/test/clojure_kubectl/helpers_test.clj
@@ -40,12 +40,38 @@
             :flags [:--dry-run]}
            (-> (kubectl)
                (flag :--dry-run)))))
+
   (testing "multiple flags"
     (is (= {:path "kubectl"
             :flags [[:-l "foo"] [:-l "bar"]]}
            (-> (kubectl)
                (flag :-l "foo")
                (flag :-l "bar"))))))
+
+(deftest kubectl-builder-test
+  (is (= {:path "kubectl"
+          :command :get
+          :type :pods
+          :flags [[:-l "foo"]
+                  [:-l "bar"]]}
+         (-> (kubectl-builder :pods
+                              :get
+                              {:flags [[:-l "foo"]]})
+             (flag :-l "bar"))))
+
+  (is (= {:path "kubectl"
+          :command :get
+          :type :pods
+          :flags [[:-n "test"]
+                  [:-l "env=prod"]
+                  [:-l "foo"]
+                  [:-l "bar"]]}
+         (-> (kubectl-builder :pods
+                              :get
+                              {:namespace "test"
+                               :flags [[:-l "foo"]]
+                               :labels {:env "prod"}})
+             (flag :-l "bar")))))
 
 (deftest namespace-test
   (is (= {:path "kubectl"

--- a/test/clojure_kubectl/kubectl_test.clj
+++ b/test/clojure_kubectl/kubectl_test.clj
@@ -40,10 +40,11 @@
                                :command :get
                                :type :pods
                                :flags [[:-n :backend] [:-l "label=name"]]})))
-  (is (= ["kubectl" "get" "pods" "-n" "backend" "-l" "label=first"  "-l" "label=second"]
+  (is (= ["kubectl" "get" "pods" "-n" "backend" "-l" "label=first"  "-l" "label=second" "-l" "foo"]
          (build-shell-command {:path "kubectl"
                                :command :get
                                :type :pods
                                :flags [[:-n :backend]
                                        [:-l "label=first"]
-                                       [:-l "label=second"]]}))))
+                                       [:-l "label=second"]
+                                       [:-l "foo"]]}))))


### PR DESCRIPTION
making **concat** to return *vector* instead of *list* will keep the labels order when use the **flags** option